### PR TITLE
Fix three critical data extraction issues

### DIFF
--- a/mcp_simple_pubmed/server.py
+++ b/mcp_simple_pubmed/server.py
@@ -98,7 +98,10 @@ async def search_pubmed(query: str, max_results: int = 10) -> str:
                 
             # Add PubMed URLs
             article["pubmed_url"] = f"https://pubmed.ncbi.nlm.nih.gov/{pmid}/"
-            article["pubmed_fulltext_url"] = f"https://www.ncbi.nlm.nih.gov/pmc/articles/{pmid}/"
+
+            # Add PMC URL only if PMCID is available
+            if "pmcid" in article:
+                article["pmc_url"] = f"https://www.ncbi.nlm.nih.gov/pmc/articles/{article['pmcid']}/"
             
             articles_with_resources.append(article)
 


### PR DESCRIPTION
This commit addresses three important issues with PubMed data extraction:

1. Abstract Truncation Fix:
   - Previously only retrieved first AbstractText element
   - Now properly concatenates all sections (PURPOSE, METHOD, RESULTS, CONCLUSIONS)
   - Preserves section labels for structured abstracts
   - Maintains compatibility with single-section abstracts

2. Keywords and MeSH Terms Extraction:
   - Added extraction of author-supplied keywords
   - Added extraction of MeSH (Medical Subject Headings) terms with qualifiers
   - Includes MeSH UI identifiers for precise categorization
   - Cleans up keyword text (removes trailing periods)

3. PMC URL Generation Fix:
   - Fixed incorrect URL generation that used PMID instead of PMCID
   - Now properly extracts PMCID from PubMed XML
   - Only generates PMC URL when PMCID is available
   - Correct format: /pmc/articles/PMC[ID]/ instead of /pmc/articles/[PMID]/

These fixes ensure complete and accurate article metadata for proper filtering, categorization, and access to full-text articles.

Tested with PMIDs: 40959477, 38709811, 39384744